### PR TITLE
Client application specific scopes

### DIFF
--- a/lib/doorkeeper/models/application.rb
+++ b/lib/doorkeeper/models/application.rb
@@ -1,6 +1,7 @@
 module Doorkeeper
   class Application
     include OAuth::Helpers
+    include Models::Scopes
 
     has_many :access_grants, dependent: :destroy, class_name: 'Doorkeeper::AccessGrant'
     has_many :access_tokens, dependent: :destroy, class_name: 'Doorkeeper::AccessToken'

--- a/lib/doorkeeper/models/mongoid2/application.rb
+++ b/lib/doorkeeper/models/mongoid2/application.rb
@@ -2,6 +2,7 @@ module Doorkeeper
   class Application
     include Mongoid::Document
     include Mongoid::Timestamps
+    include Models::Mongoid::Scopes
 
     self.store_in :oauth_applications
 

--- a/lib/doorkeeper/models/mongoid3_4/application.rb
+++ b/lib/doorkeeper/models/mongoid3_4/application.rb
@@ -2,6 +2,7 @@ module Doorkeeper
   class Application
     include Mongoid::Document
     include Mongoid::Timestamps
+    include Models::Mongoid::Scopes
 
     self.store_in collection: :oauth_applications
 

--- a/lib/doorkeeper/oauth/client_credentials/validation.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validation.rb
@@ -13,7 +13,7 @@ module Doorkeeper
         validate :scopes, error: :invalid_scope
 
         def initialize(server, request)
-          @server, @request = server, request
+          @server, @request, @client = server, request, request.client
           validate
         end
 
@@ -25,7 +25,14 @@ module Doorkeeper
 
         def validate_scopes
           return true unless @request.original_scopes.present?
-          ScopeChecker.valid?(@request.original_scopes, @server.scopes)
+
+          application_scopes = if @client.present?
+                                 @client.application.scopes
+                               else
+                                 ''
+                               end
+
+          ScopeChecker.valid?(@request.original_scopes, @server.scopes, application_scopes)
         end
       end
     end

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -7,10 +7,16 @@ module Doorkeeper
           current_scopes == scopes
         end
 
-        def self.valid?(scope, server_scopes)
+        def self.valid?(scope, server_scopes, application_scopes = '')
+          valid_scopes = if application_scopes.present?
+                           server_scopes & application_scopes
+                         else
+                           server_scopes
+                         end
+
           scope.present? &&
-          scope !~ /[\n|\r|\t]/ &&
-          server_scopes.has_scopes?(OAuth::Scopes.from_string(scope))
+            scope !~ /[\n|\r|\t]/ &&
+            valid_scopes.has_scopes?(OAuth::Scopes.from_string(scope))
         end
       end
     end

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -9,7 +9,7 @@ module Doorkeeper
 
         def self.valid?(scope, server_scopes, application_scopes = '')
           valid_scopes = if application_scopes.present?
-                           server_scopes & application_scopes
+                           application_scopes
                          else
                            server_scopes
                          end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -32,7 +32,7 @@ module Doorkeeper
 
       def validate_scopes
         return true unless @original_scopes.present?
-        ScopeChecker.valid?(@original_scopes, @server.scopes)
+        ScopeChecker.valid? @original_scopes, server.scopes, client.try(:scopes)
       end
 
       def validate_resource_owner

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -48,7 +48,11 @@ module Doorkeeper
 
       def validate_scopes
         return true unless scope.present?
-        Helpers::ScopeChecker.valid? scope, server.scopes
+        if client.application.scopes.empty?
+          Helpers::ScopeChecker.valid?(scope, server.scopes)
+        else
+          Helpers::ScopeChecker.valid?(scope, server.scopes & client.application.scopes)
+        end
       end
 
       # TODO: test uri should be matched against the client's one

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -48,11 +48,11 @@ module Doorkeeper
 
       def validate_scopes
         return true unless scope.present?
-        if client.application.scopes.empty?
-          Helpers::ScopeChecker.valid?(scope, server.scopes)
-        else
-          Helpers::ScopeChecker.valid?(scope, server.scopes & client.application.scopes)
-        end
+        Helpers::ScopeChecker.valid?(
+          scope,
+          server.scopes,
+          client.application.scopes
+        )
       end
 
       # TODO: test uri should be matched against the client's one

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -17,7 +17,7 @@ module Doorkeeper
         end
       end
 
-      delegate :each, to: :@scopes
+      delegate :each, :empty?, to: :@scopes
 
       def initialize
         @scopes = []
@@ -54,6 +54,11 @@ module Doorkeeper
 
       def <=>(other)
         self.map(&:to_s).sort <=> other.map(&:to_s).sort
+      end
+
+      def &(other)
+        other_array = other.present? ? other.all : []
+        self.class.from_array(all & other_array)
       end
     end
   end

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -5,6 +5,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.string  :uid,          null: false
       t.string  :secret,       null: false
       t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
       t.timestamps
     end
 

--- a/spec/dummy/db/migrate/20150720133530_add_scopes_to_application.rb
+++ b/spec/dummy/db/migrate/20150720133530_add_scopes_to_application.rb
@@ -1,0 +1,5 @@
+class AddScopesToApplication < ActiveRecord::Migration
+  def change
+    add_column :oauth_applications, :scopes, :string, null: false, default: ''
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130902175349) do
+ActiveRecord::Schema.define(version: 20150720133530) do
 
   create_table 'oauth_access_grants', force: true do |t|
     t.integer  'resource_owner_id',                 null: false
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20130902175349) do
     t.datetime 'updated_at',                   null: false
     t.integer  'owner_id'
     t.string   'owner_type'
+    t.string   'scopes',                       :default => '', :null => false
   end
 
   add_index 'oauth_applications', %w(owner_id owner_type), name: 'index_oauth_applications_on_owner_id_and_owner_type'

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -76,12 +76,12 @@ module Doorkeeper::OAuth::Helpers
         Doorkeeper::OAuth::Scopes.from_string 'common svr'
       end
       let(:application_scopes) do
-        Doorkeeper::OAuth::Scopes.from_string 'common'
+        Doorkeeper::OAuth::Scopes.from_string 'app123'
       end
 
-      it 'is valid if scope is included in the server and the application' do
+      it 'is valid if scope is included in the application scope list' do
         expect(ScopeChecker.valid?(
-                 'common',
+                 'app123',
                  server_scopes,
                  application_scopes
                )).to be_truthy

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -70,5 +70,30 @@ module Doorkeeper::OAuth::Helpers
     it 'is invalid if any scope is not included in server scopes' do
       expect(ScopeChecker.valid?('scope another', server_scopes)).to be_falsey
     end
+
+    context 'with application_scopes' do
+      let(:server_scopes) do
+        Doorkeeper::OAuth::Scopes.from_string 'common svr'
+      end
+      let(:application_scopes) do
+        Doorkeeper::OAuth::Scopes.from_string 'common'
+      end
+
+      it 'is valid if scope is included in the server and the application' do
+        expect(ScopeChecker.valid?(
+                 'common',
+                 server_scopes,
+                 application_scopes
+               )).to be_truthy
+      end
+
+      it 'is invalid if any scope is not included in the application' do
+        expect(ScopeChecker.valid?(
+                 'svr',
+                 server_scopes,
+                 application_scopes
+               )).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
If there no scopes (empty string) defined in the Doorkeeper::Application record, PreAuthorization should only compare scopes against the config/server scopes. If there are scopes on the Doorkeeper::Application record, the set of valid scopes is the intersection of the config/server and the Doorkeeper::Application record scopes.

The patch is picked from 
https://github.com/doorkeeper-gem/doorkeeper/pull/469
https://github.com/doorkeeper-gem/doorkeeper/pull/538
https://github.com/doorkeeper-gem/doorkeeper/pull/678
